### PR TITLE
Add content for gpu-as-a-service lab for RHOAI bootcamp

### DIFF
--- a/examples/gpu-as-a-service/README.md
+++ b/examples/gpu-as-a-service/README.md
@@ -1,0 +1,9 @@
+# GPU as a Service LAB
+
+## Purpose
+
+This component is designed to enable to enable time slicing on GPUs.
+
+To learn more about the monitoring dashboard, please refer to the official [docs](
+https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/time-slicing-gpus-in-openshift.html)
+

--- a/examples/gpu-as-a-service/clean-kueue.sh
+++ b/examples/gpu-as-a-service/clean-kueue.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "Deleting all rayclusters"
+oc delete raycluster --all --all-namespaces > /dev/null
+
+echo "Deleting all localqueue"
+oc delete localqueue --all --all-namespaces > /dev/null
+
+echo "Deleting all clusterqueues"
+oc delete clusterqueue --all --all-namespaces > /dev/null
+
+echo "Deleting all resourceflavors"
+oc delete resourceflavor --all --all-namespaces > /dev/null

--- a/examples/gpu-as-a-service/default-flavor.yaml
+++ b/examples/gpu-as-a-service/default-flavor.yaml
@@ -1,0 +1,4 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor

--- a/examples/gpu-as-a-service/gpu-flavor.yaml
+++ b/examples/gpu-as-a-service/gpu-flavor.yaml
@@ -1,0 +1,11 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: gpu-flavor
+spec:
+  nodeLabels:
+    nvidia.com/gpu.present: "true"
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule

--- a/examples/gpu-as-a-service/kueue-cluster.yaml
+++ b/examples/gpu-as-a-service/kueue-cluster.yaml
@@ -1,0 +1,16 @@
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks:
+      - BatchJob
+    preemption:
+      preemptionPolicy: FairSharing

--- a/examples/gpu-as-a-service/kueue-namespace.yaml
+++ b/examples/gpu-as-a-service/kueue-namespace.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kueue-operator
+  annotations:
+    openshift.io/description: "openshift-kueue-operator"
+    openshift.io/display-name: "openshift-kueue-operator"
+    openshift.io/requester: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
+spec:
+  finalizers:
+    - kubernetes
+...

--- a/examples/gpu-as-a-service/kueue-operator-group.yaml
+++ b/examples/gpu-as-a-service/kueue-operator-group.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: Kueue.v1.kueue.openshift.io
+  name: openshift-kueue-operator
+  namespace: openshift-kueue-operator
+spec:
+  upgradeStrategy: Default
+status:
+  namespaces:
+  - ""

--- a/examples/gpu-as-a-service/kueue-operator.yaml
+++ b/examples/gpu-as-a-service/kueue-operator.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/kueue-operator.openshift-kueue-operator: ""
+  name: kueue-operator
+  namespace: openshift-kueue-operator
+spec:
+  channel: stable-v1.0
+  installPlanApproval: Automatic
+  name: kueue-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: kueue-operator.v1.0.1

--- a/examples/gpu-as-a-service/kustomization.yaml
+++ b/examples/gpu-as-a-service/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - kueue-namespace.yaml
+  - kueue-operator.yaml
+  - kueue-operator-group.yaml
+  - kueue-cluster.yaml
+  - team-a-ns.yaml
+  - team-b-ns.yaml
+  - team-a-rb.yaml
+  - team-b-rb.yaml
+  - default-flavor.yaml
+  - gpu-flavor.yaml
+  - team-a-cq.yaml
+  - team-b-cq.yaml
+  - shared-cq.yaml
+  - team-a-local-queue.yaml
+  - team-b-local-queue.yaml
+  - team-b-ray-cluster-dev.yaml
+  - team-a-ray-cluster-prod.yaml

--- a/examples/gpu-as-a-service/sample.py
+++ b/examples/gpu-as-a-service/sample.py
@@ -1,0 +1,28 @@
+import ray
+import os
+import requests
+
+ray.init()
+
+@ray.remote
+class Counter:
+    def __init__(self):
+        # Used to verify runtimeEnv
+        self.name = os.getenv("counter_name", "test_counter")
+        assert self.name == "test_counter"
+        self.counter = 0
+
+    def inc(self):
+        self.counter += 1
+
+    def get_counter(self):
+        return "{} got {}".format(self.name, self.counter)
+
+counter = Counter.remote()
+
+for _ in range(5):
+    ray.get(counter.inc.remote())
+    print(ray.get(counter.get_counter.remote()))
+
+# Verify that the correct runtime env was used for the job.
+assert requests.__version__ == "2.31.0"

--- a/examples/gpu-as-a-service/shared-cq.yaml
+++ b/examples/gpu-as-a-service/shared-cq.yaml
@@ -1,0 +1,24 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "shared-cq"
+spec:
+  preemption:
+    reclaimWithinCohort: Any
+    borrowWithinCohort:
+      policy: LowerPriority
+      maxPriorityThreshold: 100
+    withinClusterQueue: Never
+  namespaceSelector: {}  #  match all.
+  cohort: "team-ab"
+  resourceGroups:
+  - coveredResources:
+    - cpu
+    - memory
+    flavors:
+    - name: "default-flavor"
+      resources:
+      - name: "cpu"
+        nominalQuota: 2
+      - name: "memory"
+        nominalQuota: 8Gi

--- a/examples/gpu-as-a-service/team-a-cq.yaml
+++ b/examples/gpu-as-a-service/team-a-cq.yaml
@@ -1,0 +1,34 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: team-a-cq
+spec:
+  preemption:
+    reclaimWithinCohort: Any
+    borrowWithinCohort:
+      policy: LowerPriority
+      maxPriorityThreshold: 100
+    withinClusterQueue: Never
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: team-a
+  queueingStrategy: BestEffortFIFO
+  cohort: team-ab
+  resourceGroups:
+  - coveredResources:
+    - cpu
+    - memory
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: cpu
+        nominalQuota: 0
+      - name: memory
+        nominalQuota: 0
+  - coveredResources:
+    - nvidia.com/gpu
+    flavors:
+    - name: gpu-flavor
+      resources:
+      - name: nvidia.com/gpu
+        nominalQuota: "1"

--- a/examples/gpu-as-a-service/team-a-local-queue.yaml
+++ b/examples/gpu-as-a-service/team-a-local-queue.yaml
@@ -1,0 +1,7 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: local-queue
+  namespace: team-a
+spec:
+  clusterQueue: team-a-cq

--- a/examples/gpu-as-a-service/team-a-ns.yaml
+++ b/examples/gpu-as-a-service/team-a-ns.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: team-a
+    opendatahub.io/dashboard: "true"
+    kueue.openshift.io/managed: "true"
+  name: team-a

--- a/examples/gpu-as-a-service/team-a-ray-cluster-prod.yaml
+++ b/examples/gpu-as-a-service/team-a-ray-cluster-prod.yaml
@@ -1,0 +1,72 @@
+# Team A is using prod-priority and will prempt team A because shared-cq quota
+# is CPU: 10 and mem: 64G which has no spare quota for team A (GPU:10, MEM:24G).
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  labels:
+    kueue.x-k8s.io/queue-name: local-queue
+    kueue.x-k8s.io/priority-class: prod-priority
+  name: raycluster-prod
+  namespace: team-a
+spec:
+  rayVersion: 2.7.0
+  headGroupSpec:
+    enableIngress: false
+    rayStartParams:
+      block: "true"
+      dashboard-host: 0.0.0.0
+      num-gpus: "0"
+    template:
+      metadata: {}
+      spec:
+        containers:
+        - env:
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: "void"
+          image: quay.io/project-codeflare/ray:2.20.0-py39-cu118
+          imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - ray stop
+          name: ray-head
+          resources:
+            limits:
+              cpu: "2"
+              memory: 3G
+            requests:
+              cpu: "2"
+              memory: 3G
+  suspend: false
+  workerGroupSpecs:
+  - groupName: small-group-test
+    maxReplicas: 1
+    minReplicas: 1
+    numOfHosts: 1
+    rayStartParams:
+      block: "true"
+      num-gpus: "1"
+    replicas: 1
+    scaleStrategy: {}
+    template:
+      spec:
+        containers:
+        - name: machine-learning
+          image: quay.io/project-codeflare/ray:2.20.0-py39-cu118
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "2"
+              memory: 3G
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "2"
+              memory: 3G
+              nvidia.com/gpu: "1"
+        tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists

--- a/examples/gpu-as-a-service/team-a-rb.yaml
+++ b/examples/gpu-as-a-service/team-a-rb.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: edit
+  namespace: team-a
+subjects:
+  - kind: ServiceAccount
+    name: team-a
+    namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit

--- a/examples/gpu-as-a-service/team-b-cq.yaml
+++ b/examples/gpu-as-a-service/team-b-cq.yaml
@@ -1,0 +1,29 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: team-b-cq
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: team-b
+  queueingStrategy: BestEffortFIFO
+  cohort: team-ab
+  resourceGroups:
+  - coveredResources:
+    - nvidia.com/gpu
+    flavors:
+    - name: gpu-flavor
+      resources:
+      - name: nvidia.com/gpu
+        nominalQuota: "0"
+        borrowingLimit: "0"
+  - coveredResources:
+    - cpu
+    - memory
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: cpu
+        nominalQuota: 0
+      - name: memory
+        nominalQuota: 0

--- a/examples/gpu-as-a-service/team-b-local-queue.yaml
+++ b/examples/gpu-as-a-service/team-b-local-queue.yaml
@@ -1,0 +1,7 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: local-queue
+  namespace: team-b
+spec:
+  clusterQueue: team-b-cq

--- a/examples/gpu-as-a-service/team-b-ns.yaml
+++ b/examples/gpu-as-a-service/team-b-ns.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: team-b
+    opendatahub.io/dashboard: "true"
+    kueue.openshift.io/managed: "true"
+  name: team-b

--- a/examples/gpu-as-a-service/team-b-ray-cluster-dev.yaml
+++ b/examples/gpu-as-a-service/team-b-ray-cluster-dev.yaml
@@ -1,0 +1,70 @@
+# Team B is using dev-priority
+# Total CPU: 6
+# Total Mem: 16G
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  labels:
+    kueue.x-k8s.io/queue-name: local-queue
+    kueue.x-k8s.io/priority-class: dev-priority
+  name: raycluster-dev
+  namespace: team-b
+spec:
+  rayVersion: 2.7.0
+  headGroupSpec:
+    enableIngress: false
+    rayStartParams:
+      block: "true"
+      dashboard-host: 0.0.0.0
+      num-gpus: "0"
+    template:
+      metadata: {}
+      spec:
+        containers:
+        - env:
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: "void"
+          image: quay.io/project-codeflare/ray:2.20.0-py39-cu118
+          imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - ray stop
+          name: ray-head
+          resources:
+            limits:
+              cpu: "2"
+              memory: 3G
+            requests:
+              cpu: "2"
+              memory: 3G
+  suspend: false
+  workerGroupSpecs:
+  - groupName: small-group-test
+    maxReplicas: 1
+    minReplicas: 1
+    numOfHosts: 1
+    rayStartParams:
+      block: "true"
+      num-gpus: "0"
+    replicas: 1
+    scaleStrategy: {}
+    template:
+      spec:
+        containers:
+        - env:
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: "void"
+          name: machine-learning
+          image: quay.io/project-codeflare/ray:2.20.0-py39-cu118
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "2"
+              memory: 3G
+            requests:
+              cpu: "2"
+              memory: 3G

--- a/examples/gpu-as-a-service/team-b-rb.yaml
+++ b/examples/gpu-as-a-service/team-b-rb.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: edit
+  namespace: team-b
+subjects:
+  - kind: ServiceAccount
+    name: team-b
+    namespace: team-b
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit

--- a/examples/gpu-as-a-service/workloadpriority.yml
+++ b/examples/gpu-as-a-service/workloadpriority.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: prod-priority
+value: 1000
+description: "Priority class for prod jobs"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: dev-priority
+value: 100
+description: "Priority class for development jobs"


### PR DESCRIPTION
# What does this PR do?
Add examples/gpu-as-a-service to be used in the RHOAI bootcamp. The overall idea is to maintain the infrastructure in the ai-accelerator and move to this repo the examples used by the different labs.


## Test Plan
* Deploy with the bootstrap a new ai-accelerator cluster with the overlay rhoai-stable-2.22-aws-gpu-time-sliced.
* Execute the kustomization resource inside the /examples/gpu-as-a-service

Test the concepts from the chapter: https://redhat-ai-services.github.io/rhoai-platform-foundation-bootcamp-instructions/modules/90_gpu_as_a_service_intro.html


